### PR TITLE
Add application wrapper and initial routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Layout from '@/Layout';
+import { Routes, Route } from 'react-router-dom';
+import { createPageUrl } from '@/utils';
+import Home from '@/pages/Home';
+import Albums from '@/pages/Albums';
+import AlbumDetail from '@/pages/AlbumDetail';
+import CreateMemory from '@/pages/CreateMemory';
+import EditMemory from '@/pages/EditMemory';
+import Profile from '@/pages/Profile';
+
+export default function App() {
+  return (
+    <Layout>
+      <Routes>
+        <Route path={createPageUrl('Home')} element={<Home />} />
+        <Route path={createPageUrl('Albums')} element={<Albums />} />
+        <Route path={createPageUrl('AlbumDetail')} element={<AlbumDetail />} />
+        <Route path={createPageUrl('CreateMemory')} element={<CreateMemory />} />
+        <Route path={createPageUrl('EditMemory')} element={<EditMemory />} />
+        <Route path={createPageUrl('Profile')} element={<Profile />} />
+      </Routes>
+    </Layout>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import App from './App'; // or Layout + Routes
+import App from '@/App';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <BrowserRouter>


### PR DESCRIPTION
## Summary
- add `App` component that wraps `Layout` and defines routes for all pages
- update main entry point to render `App`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d874b4ac83289293b165c27eca73